### PR TITLE
usage()/help() use stdout and exit successfully

### DIFF
--- a/conmain.c
+++ b/conmain.c
@@ -256,7 +256,7 @@ void parse_switch (char *arg)
 
 void usage(void)
 {
-    fprintf(stderr,
+	fprintf(stdout,
 	"Dzip v%u.%u: specializing in Quake demo compression\n\n"
 
 	"Compression:         dzip <filenames> [-o <outputfile>]\n"
@@ -277,7 +277,7 @@ void usage(void)
 	MAJOR_VERSION, MINOR_VERSION
     );
 
-    exit(1);
+    exit(0);
 }
 
 void DoFiles (char *fname, void (*func)(char *));


### PR DESCRIPTION
According to GNU coding standards for [help](https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html) and [version](https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html) it's recommend to print it on standard output, then exit successfully.
This way one cat process help or redirect it to file with \`>'. Also, although it's not using \`--help' nor \`-h' for that matter, help is not fail nevertheless, so it should end program successfully. Returning 1 indicates failure of some kind.

